### PR TITLE
READ.md 정보 관련 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ MIT 라이센서를 따릅니다.
 ## 필요한것은?
 - node.js * fs.writefile 함수의 인자 변경으로 인해 버전 8까지만 정상작동합니다.
 - npm modules * 아래의 모듈을 전부 깔아주셔야 정상적으로 작동합니다.
- - http
- - https
- - querystring
- - async
- - crypto
- - stream
- - fs
- - iconv-lite
- - cheerio
- - html-entities
+  - http
+  - https
+  - querystring
+  - async
+  - crypto
+  - stream
+  - fs
+  - iconv-lite
+  - cheerio
+  - html-entities
  
 ## 설정은
  - core/config.js 에서 아래의 항목을 수정하여 주세요!!

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MIT 라이센서를 따릅니다.
 
 ## 필요한것은?
 - node.js * fs.writefile 함수의 인자 변경으로 인해 버전 8까지만 정상작동합니다.
-- npm modules
+- npm modules * 아래의 모듈을 전부 깔아주셔야 정상적으로 작동합니다.
  - http
  - https
  - querystring

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MIT 라이센서를 따릅니다.
 다만 원 라이센스의 github 경로는 명시해주세요.
 
 ## 필요한것은?
-- node.js
+- node.js * fs.writefile 함수의 인자 변경으로 인해 버전 8까지만 정상작동합니다.
 - npm modules
  - http
  - https


### PR DESCRIPTION
fs 모듈 업데이트로 인한 현재 코드의 사용 불가로(fs.writeFile의 CALLBACK 문제 발생),
사용 가능한 node.js 버전 명확히 명시, 마크다운 문법에 맞춰 리드미 일부 수정.